### PR TITLE
Minify JS output

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,4 +4,5 @@ export default defineConfig({
   dts: true,
   sourcemap: false,
   entry: ['src/index.ts'],
+  minify: true,
 })


### PR DESCRIPTION
This change reduces the bundle size from ~ 3.5 MB to 3 MB, not a great improvement but it's still something 